### PR TITLE
Bump version to match Keycloak version 26.0.7

### DIFF
--- a/localstack/docker-compose.yml
+++ b/localstack/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - keycloak_network
 
   keycloak:
-    image: bitnami/keycloak:24.0.5
+    image: bitnami/keycloak:26.0.7
     container_name: keycloak
     environment:
       - KEYCLOAK_DATABASE_HOST=postgres

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>no.ssb.dapla.keycloak</groupId>
     <artifactId>dapla-team-keycloak-protocol-mapper</artifactId>
-    <version>24.0.6-SNAPSHOT</version>
+    <version>26.0.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Dapla Team Protocol Mapper for Keycloak</name>
@@ -20,7 +20,7 @@
         <commons-codec.version>1.17.0</commons-codec.version>
         <jackson-jq.version>1.0.0-preview.20240207</jackson-jq.version>
         <junit.version>5.10.2</junit.version>
-        <keycloak.version>24.0.5</keycloak.version>
+        <keycloak.version>26.0.7</keycloak.version>
         <lombok.version>1.18.32</lombok.version>
         <okhttp.version>5.0.0-alpha.14</okhttp.version>
         <mockito.version>5.12.0</mockito.version>


### PR DESCRIPTION
Internal-ref: [DPSKY-868]

[DPSKY-868]: https://statistics-norway.atlassian.net/browse/DPSKY-868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ