### PR TITLE
Update default value for dapla team api

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ resource "keycloak_generic_protocol_mapper" "dapla_userinfo_mapper" {
     "access.token.claim"                          = true
     "userinfo.token.claim"                        = true
     "dapla-team-api.impl"                         = "Default"
-    "dapla-team-api.url"                          = "https://dapla-team-api-v2.prod-bip-app.ssb.no"
+    "dapla-team-api.url"                          = "http://dapla-team-api.dapla-platform"
     "dapla.userinfo.nested"                       = false
     "dapla.userinfo.group-suffix-include-regex"   = "developers|data-admins"
     "dapla.userinfo.exclude-teams-without-groups" = true

--- a/src/main/java/no/ssb/dapla/keycloak/mappers/daplauserinfo/DaplaUserInfoMapper.java
+++ b/src/main/java/no/ssb/dapla/keycloak/mappers/daplauserinfo/DaplaUserInfoMapper.java
@@ -64,7 +64,7 @@ public class DaplaUserInfoMapper extends AbstractTokenMapper {
                                 Root URL for the Dapla Team API.
                                 This is not relevant if 'Dapla Team API Impl' is Dummy.""")
                         .type(ConfigPropertyType.STRING)
-                        .defaultValue("https://dapla-team-api-v2.prod-bip-app.ssb.no")
+                        .defaultValue("http://dapla-team-api.dapla-platform")
                         .build(),
 
                 configProperty()

--- a/src/test/java/no/ssb/dapla/keycloak/mappers/daplauserinfo/DaplaUseInfoMapperIT.java
+++ b/src/test/java/no/ssb/dapla/keycloak/mappers/daplauserinfo/DaplaUseInfoMapperIT.java
@@ -37,7 +37,7 @@ public class DaplaUseInfoMapperIT {
     @BeforeEach
     void setUp() {
         service = new DefaultDaplaTeamApiService(DefaultDaplaTeamApiService.Config.builder()
-                .teamApiUrl(URI.create("https://dapla-team-api-v2.prod-bip-app.ssb.no"))
+                .teamApiUrl(URI.create("http://dapla-team-api.dapla-platform"))
                 .build());
 
         protocolMapperModel = new ProtocolMapperModel();
@@ -74,7 +74,7 @@ public class DaplaUseInfoMapperIT {
     void testMapToClaimUsingDefaultDaplaTeamApiService() {
         protocolMapperModel.setConfig(Map.of(
                 ConfigPropertyKey.VERBOSE_LOGGING, Boolean.TRUE.toString(),
-                DaplaUserInfoMapper.ConfigPropertyKey.API_URL, "https://dapla-team-api-v2.prod-bip-app.ssb.no",
+                DaplaUserInfoMapper.ConfigPropertyKey.API_URL, "http://dapla-team-api.dapla-platform",
                 DaplaUserInfoMapper.ConfigPropertyKey.API_IMPL, DefaultDaplaTeamApiService.NAME,
                 DaplaUserInfoMapper.ConfigPropertyKey.NESTED_TEAMS, Boolean.TRUE.toString(),
                 DaplaUserInfoMapper.ConfigPropertyKey.EXCLUDE_TEAMS_WITHOUT_GROUPS, Boolean.FALSE.toString(),

--- a/src/test/java/no/ssb/dapla/keycloak/services/teamapi/DefaultDaplaTeamApiServiceIT.java
+++ b/src/test/java/no/ssb/dapla/keycloak/services/teamapi/DefaultDaplaTeamApiServiceIT.java
@@ -20,7 +20,7 @@ class DefaultDaplaTeamApiServiceIT {
     @BeforeEach
     public void setup() {
         service = new DefaultDaplaTeamApiService(DefaultDaplaTeamApiService.Config.builder()
-                .teamApiUrl(URI.create("https://dapla-team-api-v2.prod-bip-app.ssb.no"))
+                .teamApiUrl(URI.create("http://dapla-team-api.dapla-platform"))
                 .build());
     }
 


### PR DESCRIPTION
The default value is the internal instance in the same cluster.
[DPSKY-878]

[DPSKY-878]: https://statistics-norway.atlassian.net/browse/DPSKY-878?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ